### PR TITLE
add federated creds e2e demo

### DIFF
--- a/.deploy/deploy_federated_demo.py
+++ b/.deploy/deploy_federated_demo.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from azure.identity import WorkloadIdentityCredential
+
+from fabric_cicd import change_log_level, FabricWorkspace, publish_all_items
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        msg = f"Missing required environment variable: {name}"
+        raise RuntimeError(msg)
+    return value
+
+
+def main() -> None:
+    workspace_id = require_env("FABRIC_WORKSPACE_ID")
+    target_environment = os.getenv("FABRIC_TARGET_ENVIRONMENT", "demo")
+
+    repo_root = Path(os.getenv("GITHUB_WORKSPACE", str(Path(__file__).resolve().parent.parent.parent)))
+    repository_directory = str(repo_root / "sample" / "workspace")
+
+    client_id = require_env("AZURE_CLIENT_ID")
+    tenant_id = require_env("AZURE_TENANT_ID")
+    federated_token_file = require_env("AZURE_FEDERATED_TOKEN_FILE")
+
+    print(f"AZURE_CLIENT_ID: {client_id}")
+    print(f"AZURE_TENANT_ID: {tenant_id}")
+    print(f"AZURE_FEDERATED_TOKEN_FILE exists: {os.path.exists(federated_token_file)}")
+    print(f"Repository directory: {repository_directory}")
+    print(f"Target environment: {target_environment}")
+
+    credential = WorkloadIdentityCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        token_file_path=federated_token_file,
+    )
+    
+    change_log_level("DEBUG")
+
+    workspace = FabricWorkspace(
+        workspace_id=workspace_id,
+        repository_directory=repository_directory,
+        environment=target_environment,
+        item_type_in_scope=["Environment", "Notebook", "DataPipeline"],
+        token_credential=credential,
+    )
+
+    publish_all_items(workspace)
+
+
+if __name__ == "__main__":
+    main()

--- a/.deploy/validate_federated_auth.py
+++ b/.deploy/validate_federated_auth.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+
+from azure.identity import WorkloadIdentityCredential
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        msg = f"Missing required environment variable: {name}"
+        raise RuntimeError(msg)
+    return value
+
+
+def main() -> None:
+    client_id = require_env("AZURE_CLIENT_ID")
+    tenant_id = require_env("AZURE_TENANT_ID")
+    federated_token_file = require_env("AZURE_FEDERATED_TOKEN_FILE")
+
+    print(f"AZURE_CLIENT_ID: {client_id}")
+    print(f"AZURE_TENANT_ID: {tenant_id}")
+    print(f"AZURE_FEDERATED_TOKEN_FILE exists: {os.path.exists(federated_token_file)}")
+
+    credential = WorkloadIdentityCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        token_file_path=federated_token_file,
+    )
+
+    token = credential.get_token("https://api.fabric.microsoft.com/.default")
+
+    print("Successfully acquired Fabric token using federated credentials.")
+    print(f"Token expires_on: {token.expires_on}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/e2e-federated-demo.yml
+++ b/.github/workflows/e2e-federated-demo.yml
@@ -1,0 +1,49 @@
+name: E2E Federated Demo
+
+on:
+    workflow_dispatch:
+        inputs:
+            target_environment:
+                description: fabric-cicd environment name
+                required: false
+                default: demo
+
+permissions:
+    id-token: write
+    contents: read
+
+jobs:
+    deploy-demo:
+        runs-on: ubuntu-latest
+        environment: e2e-demo
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
+
+            - name: Install uv
+              run: python -m pip install --upgrade pip uv
+
+            - name: Install project
+              run: uv sync
+
+            - name: Deploy demo to Fabric
+              env:
+                  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+                  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+                  FABRIC_WORKSPACE_ID: ${{ secrets.FABRIC_WORKSPACE_ID }}
+                  FABRIC_TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+              run: uv run python sample/e2e/deploy_federated_demo.py
+
+            - name: Upload fabric-cicd error log
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: fabric-cicd-error-log
+                  path: fabric_cicd.error.log
+                  if-no-files-found: ignore


### PR DESCRIPTION
This pull request introduces new scripts and a GitHub Actions workflow to support end-to-end (E2E) deployment and authentication testing for a federated demo environment using Azure Workload Identity. The main changes include adding deployment and validation scripts, and a workflow for automated deployment via GitHub Actions.

**New E2E Federated Demo Automation:**

* Added a new GitHub Actions workflow (`.github/workflows/e2e-federated-demo.yml`) to automate deployment of the demo environment to Microsoft Fabric using federated authentication. This workflow checks out the code, sets up Python, installs dependencies, runs the deployment script, and uploads error logs if needed.

**Deployment and Authentication Scripts:**

* Added `.deploy/deploy_federated_demo.py`, a script that deploys all items in a Fabric workspace using federated Azure credentials. It validates required environment variables, sets up the workspace, and publishes items.
* Added `.deploy/validate_federated_auth.py`, a script to validate Azure federated authentication by acquiring a Fabric API token and printing its expiration.