### PR TITLE
e2e Fed Cred Demo 5

### DIFF
--- a/.github/workflows/e2e-federated-demo.yml
+++ b/.github/workflows/e2e-federated-demo.yml
@@ -32,6 +32,13 @@ jobs:
             - name: Install project
               run: uv sync
 
+            - name: Get OIDC token
+              run: |
+                  TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+                    "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://AzureADTokenExchange" | jq -r '.value')
+                  echo "$TOKEN" > "$RUNNER_TEMP/federated-token"
+                  echo "AZURE_FEDERATED_TOKEN_FILE=$RUNNER_TEMP/federated-token" >> "$GITHUB_ENV"
+
             - name: Validate federated auth
               env:
                   AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the federated end-to-end demo to support OIDC-based authentication with Azure. The most significant change is the addition of a step to fetch an OIDC token and make it available for subsequent steps.

**Authentication improvements:**

* Added a step to retrieve an OIDC token using the GitHub Actions OIDC provider, save it to a temporary file, and set the `AZURE_FEDERATED_TOKEN_FILE` environment variable for later steps. This enables secure authentication with Azure using federated identity.
