### PR TITLE
add federated credential demo

### DIFF
--- a/.deploy/deploy_federated_demo.py
+++ b/.deploy/deploy_federated_demo.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from azure.identity import WorkloadIdentityCredential
+
+from fabric_cicd import FabricWorkspace, change_log_level, publish_all_items
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        msg = f"Missing required environment variable: {name}"
+        raise RuntimeError(msg)
+    return value
+
+
+def main() -> None:
+    workspace_id = require_env("FABRIC_WORKSPACE_ID")
+    target_environment = os.getenv("FABRIC_TARGET_ENVIRONMENT", "demo")
+
+    repo_root = Path(os.getenv("GITHUB_WORKSPACE", str(Path(__file__).resolve().parent.parent.parent)))
+    repository_directory = str(repo_root / "sample" / "workspace")
+
+    client_id = require_env("AZURE_CLIENT_ID")
+    tenant_id = require_env("AZURE_TENANT_ID")
+    federated_token_file = require_env("AZURE_FEDERATED_TOKEN_FILE")
+
+    print(f"Repository directory: {repository_directory}")
+    print(f"Target environment: {target_environment}")
+
+    credential = WorkloadIdentityCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        token_file_path=federated_token_file,
+    )
+
+    change_log_level("DEBUG")
+
+    workspace = FabricWorkspace(
+        workspace_id=workspace_id,
+        repository_directory=repository_directory,
+        environment=target_environment,
+        item_type_in_scope=["Environment", "Notebook", "DataPipeline", "Lakehouse"],
+        token_credential=credential,
+    )
+
+    publish_all_items(workspace)
+
+
+if __name__ == "__main__":
+    main()

--- a/.deploy/validate_federated_auth.py
+++ b/.deploy/validate_federated_auth.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from azure.identity import WorkloadIdentityCredential
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        msg = f"Missing required environment variable: {name}"
+        raise RuntimeError(msg)
+    return value
+
+
+def main() -> None:
+    client_id = require_env("AZURE_CLIENT_ID")
+    tenant_id = require_env("AZURE_TENANT_ID")
+    federated_token_file = require_env("AZURE_FEDERATED_TOKEN_FILE")
+
+    print(f"AZURE_CLIENT_ID: {client_id}")
+    print(f"AZURE_TENANT_ID: {tenant_id}")
+    print(f"AZURE_FEDERATED_TOKEN_FILE exists: {Path(federated_token_file).exists()}")
+
+    credential = WorkloadIdentityCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        token_file_path=federated_token_file,
+    )
+
+    token = credential.get_token("https://api.fabric.microsoft.com/.default")
+
+    print("Successfully acquired Fabric token using federated credentials.")
+    print(f"Token expires_on: {token.expires_on}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/e2e-federated-demo.yml
+++ b/.github/workflows/e2e-federated-demo.yml
@@ -1,0 +1,62 @@
+name: E2E Federated Demo
+
+on:
+    workflow_dispatch:
+        inputs:
+            target_environment:
+                description: fabric-cicd environment name
+                required: false
+                default: demo
+
+permissions:
+    id-token: write
+    contents: read
+
+jobs:
+    deploy-demo:
+        runs-on: ubuntu-latest
+        environment: PPE
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.11"
+
+            - name: Install uv
+              run: python -m pip install --upgrade pip uv
+
+            - name: Install project
+              run: uv sync
+
+            - name: Get OIDC token
+              run: |
+                  TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+                    "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://AzureADTokenExchange" | jq -r '.value')
+                  echo "$TOKEN" > "$RUNNER_TEMP/federated-token"
+                  echo "AZURE_FEDERATED_TOKEN_FILE=$RUNNER_TEMP/federated-token" >> "$GITHUB_ENV"
+
+            - name: Validate federated auth
+              env:
+                  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+                  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+              run: uv run python -u .deploy/validate_federated_auth.py
+
+            - name: Deploy demo to Fabric
+              env:
+                  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+                  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+                  FABRIC_WORKSPACE_ID: ${{ secrets.FABRIC_WORKSPACE_ID }}
+                  FABRIC_TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
+              run: uv run python -u .deploy/deploy_federated_demo.py
+
+            - name: Upload fabric-cicd error log
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: fabric-cicd-error-log
+                  path: fabric_cicd.error.log
+                  if-no-files-found: ignore


### PR DESCRIPTION
This pull request introduces a new end-to-end (E2E) workflow for deploying a demo environment using federated authentication with Azure in GitHub Actions. It adds both the workflow definition and supporting Python scripts for validating federated credentials and deploying to Microsoft Fabric via the `fabric_cicd` library.

**New E2E Federated Demo Workflow:**

* Adds a new GitHub Actions workflow (`.github/workflows/e2e-federated-demo.yml`) that automates the process of checking out the repository, setting up Python, installing dependencies, acquiring an OIDC federated token, validating federated authentication, deploying a sample workspace to Microsoft Fabric, and uploading error logs if present.

**Federated Authentication Support Scripts:**

* Introduces `.deploy/validate_federated_auth.py`, a script to verify that federated authentication can successfully acquire a Fabric access token using environment variables and Azure's `WorkloadIdentityCredential`.
* Adds `.deploy/deploy_federated_demo.py`, a deployment script that uses `fabric_cicd` to publish all relevant items (Environments, Notebooks, DataPipelines, Lakehouses) to a specified Fabric workspace, leveraging federated credentials for authentication.

**Environment Variable Handling:**

* Both scripts include a helper function (`require_env`) to enforce the presence of required environment variables for secure and robust execution. [[1]](diffhunk://#diff-bfc77533e8a23cd79e39b1137fb8f351dc6c2ea02bf288b06852482a6291ddc3R1-R39) [[2]](diffhunk://#diff-89caf21282e4c617fcb63360a263af5927468b7fe55367cde553bd94388c4fb3R1-R53)